### PR TITLE
decouple config parameters "Scheme", "Cert" and "Key"

### DIFF
--- a/config.go
+++ b/config.go
@@ -64,6 +64,10 @@ func (c *Configuration) IsHTTPS() bool {
 	return strings.Contains(Config.Scheme, "https")
 }
 
+func (c *Configuration) UseTLS() bool {
+	return Config.Cert != "" && Config.Key != ""
+}
+
 func (c *Configuration) IsPublic() bool {
 	return Config.Public
 }

--- a/main.go
+++ b/main.go
@@ -102,10 +102,14 @@ func main() {
 	listener = tl
 
 	if Config.IsHTTPS() {
-		logger.Log(kv{"fn": "main", "msg": "Using https"})
-		listener, err = wrapHttps(tl, Config.Cert, Config.Key)
-		if err != nil {
-			logger.Fatal(kv{"fn": "main", "err": "Could not create https listener: " + err.Error()})
+		if Config.UseTLS() {
+			logger.Log(kv{"fn": "main", "msg": "Using tls"})
+			listener, err = wrapHttps(tl, Config.Cert, Config.Key)
+			if err != nil {
+				logger.Fatal(kv{"fn": "main", "err": "Could not create https listener: " + err.Error()})
+			}
+		} else {
+			logger.Log(kv{"fn": "main", "msg": "Will generate https hrefs"})
 		}
 	}
 


### PR DESCRIPTION
this patch makes the `Scheme` config parameter only affect how the server
generates hrefs for stored objects, as opposed to deciding if TLS should be
used

the decision on whether or not to use TLS is now made from the presence of
`Key` and `Cert` parameters (which are required if you want it)
a new helper method can be used to conveniently check that: `Config.UseTLS()`

the use case for this change is when your server is behind a reverse proxy or a
load balancer that does TLS/SSL termination

I suspect this is going to be a fairly common setup because it's likely that
people already have the infrastructure to run e.g. nginx with TLS/SSL, maintain
keys and certificates, etc.

consider the following setup:

    https://git-server/ -> nginx (HTTP over TLS) -> lfs-server-go (plain HTTP)

without this patch, when cloning a repo, you get the following trace:

    trace git-lfs: HTTP: POST https://git-server/ksurent/lfs-test/objects/batch
    trace git-lfs: HTTP: 401
    trace git-lfs: HTTP: {"message":"Unauthorized"}
    trace git-lfs: setting repository access to basic
    trace git-lfs: run_command: 'git' config lfs.https://git-server/ksurent/lfs-test.access basic
    trace git-lfs: api: http response indicates "basic" authentication. Resubmitting...
    trace git-lfs: api: batch 1 files
    16:57:36.955645 git.c:351               trace: built-in: git 'credential' 'fill'
    trace git-lfs: Filled credentials for https://git-server/ksurent/lfs-test
    trace git-lfs: HTTP: POST https://git-server/ksurent/lfs-test/objects/batch
    trace git-lfs: HTTP: 200
    16:57:42.741014 git.c:351               trace: built-in: git 'credential' 'approve'
    trace git-lfs: HTTP: {"objects":[{"oid":"...","size":218144,"_links":{"download":{"href":"http://git-server/ksurent/lfs-test/objects/...","header":{"Accept":"application/vnd.git-lfs","Authorization":"Basic ..."}}}}]}

note how the "href" on the last line is `http://git-server` instead of
`https://git-server`
this obviously makes the git-lfs client attempt to download from a URL where
there might not even be a webserver listening

to fix this problem you can now specify the following in your config.ini:

    [Main]

    Listen = tcp://127.0.0.1:9999
    Host = git-server
    Scheme = https
    ; No Key or Cert

this will make lfs-server-go generate HTTPS hrefs while *not* using HTTPS
itself and show the correct `lfs.url` value on the management page