### PR TITLE
Introduce pending and committed meta object states

### DIFF
--- a/cassandra_service.go
+++ b/cassandra_service.go
@@ -50,6 +50,13 @@ func initializeCassandra(session *gocql.Session) error {
 		return err
 	}
 
+	// Pending table
+	q = fmt.Sprintf("create table if not exists pending_oids(oid text primary key, size bigint);")
+	session.Query(q).Exec()
+	if err != nil {
+		return err
+	}
+
 	// user management
 	q = fmt.Sprintf("create table if not exists users(username text primary key, password text);")
 	return session.Query(q).Exec()

--- a/harbour_test.go
+++ b/harbour_test.go
@@ -366,9 +366,18 @@ func seedMetaStore() error {
 		return err
 	}
 
-	rv := &RequestVars{Authorization: testAuth, Oid: contentOid, Size: contentSize, Repo: testRepo}
+	rv := &RequestVars{
+		Authorization: testAuth,
+		Oid:           contentOid,
+		Size:          contentSize,
+		Repo:          testRepo,
+	}
+
 	if _, err := testMetaStore.Put(rv); err != nil {
-		return err
+		return fmt.Errorf("Put(): %s\n", err.Error())
+	}
+	if _, err := testMetaStore.Commit(rv); err != nil {
+		return fmt.Errorf("Commit(): %s\n", err.Error())
 	}
 
 	return nil

--- a/mysql_meta_store_test.go
+++ b/mysql_meta_store_test.go
@@ -180,6 +180,7 @@ func setupMySQLMeta() error {
 	mysqlStore.client.Exec("TRUNCATE TABLE oid_maps")
 	mysqlStore.client.Exec("TRUNCATE TABLE oids")
 	mysqlStore.client.Exec("TRUNCATE TABLE projects")
+	mysqlStore.client.Exec("TRUNCATE TABLE pending_oids")
 
 	rv := &RequestVars{Authorization: testAuth, Oid: contentOid, Size: contentSize, Repo: testRepo}
 

--- a/mysql_service.go
+++ b/mysql_service.go
@@ -71,8 +71,8 @@ func NewMySQLSession() *MySQLService {
 func createTables(client *gorp.DbMap) error {
 	client.AddTableWithName(Projects{}, "projects").SetKeys(true, "id").ColMap("name").SetUnique(true)
 	client.AddTableWithName(Oids{}, "oids").SetKeys(false, "oid")
+	client.AddTableWithName(Oids{}, "pending_oids").SetKeys(false, "oid")
 	client.AddTableWithName(OidMaps{}, "oid_maps")
-	// dbmap.AddTableWithName(users{}, "users").SetKeys(false, "name")
 	err := client.CreateTablesIfNotExists()
 
 	if err != nil {


### PR DESCRIPTION
This patch changes how the LFS server works with meta data making it more
resilient in the face of failed uploads, rogue clients, etc.

Meta objects can be in two states now:
- pending
  This state indicates that there's no actual data for this MetaObject and it
  can't be downloaded.
  Server will not offer to download such objects and attempting to download
  it directly will result in a 404 error.
- committed
  This state indicates that there's data in the content store for this
  MetaObject and it can be downloaded.
  Objects in this state behave in the same way all objects did prior to this
  patch.

`MetaObject`s created with `Put()` are now considered pending by default.

`Get()` now returns only committed objects.
To get a pending object `GetPending()` can be used.

Transition from pending to committed is done using `Commit()` which should
only be called once the content store has acknowledged receiving data for the
corresponding `MetaObject`.

To summarise:

This was the workflow for processing new uploads:

```
create meta -> create content
```

and now it's this:

```
create temp meta -> create content -> commit temp meta
```

The biggest improvement from this patch is that a Batch API (or legacy API)
upload request not followed by actual Transfer API upload does not result in
un-clonable repository anymore.

To understand how this can happen look at the trace below.

A client initiates a push by requesting Batch API:

```
trace git-lfs: HTTP: POST https://git-server/ksurent/lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: {"objects":[{"oid":"fea2b0a30909b9052109dc9325336aa21c390f0c124ebebf7cd90bcc0f6e2d27","size":614400000,"_links":{"upload":{"href":"https://git-server/ksurent/lfs-test/objects/fea2b0a30909b9052109dc9325336aa21c390f0c124ebebf7cd90bcc0f6e2d27","header":{"Accept":"application/vnd.git-lfs"}}}}]}
```

At this point lfs-server-go has already created meta records for objects in
that batch.

Now the client attempts to do the actual upload:

```
trace git-lfs: Filled credentials for https://git-server/ksurent/lfs-test
trace git-lfs: HTTP: PUT https://git-server/ksurent/lfs-test/objects/fea2b0a30909b9052109dc9325336aa21c390f0c124ebebf7cd90bcc0f6e2d27
trace git-lfs: xfer: adapter "basic" worker 1 auth signal received
trace git-lfs: xfer: adapter "basic" worker 2 auth signal received
trace git-lfs: HTTP: 413
trace git-lfs: HTTP: <html>
<head><title>413 Request Entity Too Large</title></head>
<body bgcolor="white">
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

The upload is rejected by nginx sitting in front of lfs-server-go.

It's important to note here that if the upload was rejected for any other
reason (client was ^C-ed, lfs-server-go crashed, whatever) the outcome would be
the same.

The client attempts a retry but this time lfs-server-go thinks the object
already exists (because metadata already exists) so it only provides a download
link:

```
trace git-lfs: xfer: adapter "basic" worker 0 finished job for "fea2b0a30909b9052109dc9325336aa21c390f0c124ebebf7cd90bcc0f6e2d27"
trace git-lfs: tq: retrying object fea2b0a30909b9052109dc9325336aa21c390f0c124ebebf7cd90bcc0f6e2d27
trace git-lfs: tq: retrying 1 failed transfers
trace git-lfs: tq: sending batch of size 1
trace git-lfs: api: batch 1 files
trace git-lfs: Filled credentials for https://git-server/ksurent/lfs-test
trace git-lfs: HTTP: POST https://git-server/ksurent/lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: {"objects":[{"oid":"fea2b0a30909b9052109dc9325336aa21c390f0c124ebebf7cd90bcc0f6e2d27","size":614400000,"_links":{"download":{"href":"https://git-server/ksurent/lfs-test/objects/fea2b0a30909b9052109dc9325336aa21c390f0c124ebebf7cd90bcc0f6e2d27","header":{"Accept":"application/vnd.git-lfs"}}}}]}

trace git-lfs: HTTP:
trace git-lfs: xfer: adapter "basic" End()
trace git-lfs: xfer: adapter "basic" worker 1 stopping
trace git-lfs: xfer: adapter "basic" worker 0 stopping
trace git-lfs: xfer: adapter "basic" worker 2 stopping
trace git-lfs: xfer: adapter "basic" stopped
```

Which makes the client think everything is ok and the push went through:

```
Git LFS: (0 of 0 files, 1 skipped) 27.62 KB / 0 B, 600.00 MB skipped
Counting objects: 3, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 427 bytes | 0 bytes/s, done.
Total 3 (delta 0), reused 0 (delta 0)
To ssh://git-server:/home/ksurent/lfs-test
   e9e40e4..01b0bfd  master -> master
```

Trying to clone a repo in this state produces bizzare results and makes it
basically unusuable since git-lfs now throws 404 errors or every
clone/push/pull operation:

```
Cloning into 'clone2'...
remote: Counting objects: 9, done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 9 (delta 2), reused 0 (delta 0)
Receiving objects: 100% (9/9), done.
Resolving deltas: 100% (2/2), done.
Downloading 600.bin (12.00 MB)
Error downloading object: 600.bin (fea2b0a30909b9052109dc9325336aa21c390f0c124ebebf7cd90bcc0f6e2d27)

Errors logged to /home/ksurent/clone2/.git/lfs/objects/logs/20160920T165607.149929226.log
Use `git lfs logs last` to view the log.
error: external filter git-lfs smudge -- %f failed 2
error: external filter git-lfs smudge -- %f failed
fatal: 600.bin: smudge filter lfs failed
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry the checkout with 'git checkout -f HEAD'
```

With this patch failed uploads result in the entire push failing as well,
preserving metadata consistency (objects remain pending).
